### PR TITLE
Run synapse from python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.99.1.1
+ARG TAG_SYN=v0.99.2
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.99.0
+ARG TAG_SYN=v0.99.1.1
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.99.2
+ARG TAG_SYN=v0.99.3
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.99.3.2
+ARG TAG_SYN=v0.99.4
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.34.0
+ARG TAG_SYN=v0.34.1.1
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991
@@ -74,7 +74,7 @@ RUN set -ex \
     git clone --branch $BV_SYN --depth 1 https://github.com/matrix-org/synapse.git \
     && cd /synapse \
     git checkout tags/$TAG_SYN \
-    && pip install --upgrade --process-dependency-links . \
+    && pip install --upgrade .[all] \
     && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse $BV_SYN | cut -f 1) \
     && echo "synapse: $BV_SYN ($GIT_SYN)" >> /synapse.version \
     && cd / \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.33.6
+ARG TAG_SYN=v0.33.8
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-stretch
+FROM debian:9.5-slim
 
 # Maintainer
 MAINTAINER Andreas Peters <support@aventer.biz>
@@ -48,7 +48,10 @@ RUN set -ex \
         libxslt1-dev \
         linux-headers-amd64 \
         make \
-        zlib1g-dev \
+        zlib1g-dev \ 
+        python3-dev \
+        python3-setuptools \
+        libpq-dev \
     ' \
     && apt-get install -y --no-install-recommends \
         $buildDeps \
@@ -64,13 +67,16 @@ RUN set -ex \
         libxml2 \
         libxslt1.1 \
         pwgen \
+        python3 \
+        python3-pip \
+        python3-jinja2 \
         sqlite \
         zlib1g \
     ; \
-    pip install --upgrade wheel ;\
-    pip install --upgrade psycopg2;\
-    pip install --upgrade python-ldap ;\
-    pip install --upgrade lxml \
+    pip3 install --upgrade wheel ;\
+    pip3 install --upgrade psycopg2;\
+    pip3 install --upgrade python-ldap ;\
+    pip3 install --upgrade lxml \
     ; \
     git clone --branch $BV_SYN --depth 1 https://github.com/matrix-org/synapse.git \
     && cd /synapse \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-stretch
+FROM python:3.6-stretch
 
 # Maintainer
 MAINTAINER Andreas Peters <support@aventer.biz>
@@ -78,7 +78,7 @@ RUN set -ex \
     ; \
     git clone --branch hawkowl/py3-3 --depth 1 https://github.com/matrix-org/synapse.git \
     && cd /synapse \
-    git checkout tags/hawkowl/py3-3 \
+    && git checkout hawkowl/py3-3 \
     && python -m pip install --upgrade --process-dependency-links . \
     && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse hawkowl/py3-3 | cut -f 1) \
     && echo "synapse: $BV_SYN ($GIT_SYN)" >> /synapse.version \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ EXPOSE 8448
 VOLUME ["/data"]
 
 # Git branch to build from
-ARG BV_SYN=master
+ARG BV_SYN=develop
 ARG BV_TUR=master
-ARG TAG_SYN=v0.33.3
+ARG TAG_SYN=v0.33.4
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991
@@ -76,11 +76,11 @@ RUN set -ex \
     python3 -m pip install --upgrade python-ldap ;\
     python3 -m pip install --upgrade lxml \
     ; \
-    git clone --branch hawkowl/py3-3 --depth 1 https://github.com/matrix-org/synapse.git \
+    git clone --branch develop --depth 1 https://github.com/matrix-org/synapse.git \
     && cd /synapse \
-    && git checkout hawkowl/py3-3 \
+    && git checkout develop \
     && python -m pip install --upgrade --process-dependency-links . \
-    && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse hawkowl/py3-3 | cut -f 1) \
+    && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse develop | cut -f 1) \
     && echo "synapse: $BV_SYN ($GIT_SYN)" >> /synapse.version \
     && cd / \
     && rm -rf /synapse \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ MAINTAINER Andreas Peters <support@aventer.biz>
 # install homerserver template
 COPY adds/start.sh /start.sh
 
-# add supervisor configs
-COPY adds/supervisord-matrix.conf /conf/
-COPY adds/supervisord-turnserver.conf /conf/
-COPY adds/supervisord.conf /
-
 # startup configuration
 ENTRYPOINT ["/start.sh"]
 CMD ["autostart"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM python:3.7-stretch
 
 # Maintainer
 MAINTAINER Andreas Peters <support@aventer.biz>
@@ -53,8 +53,6 @@ RUN set -ex \
         libxslt1-dev \
         linux-headers-amd64 \
         make \
-        python-dev \
-        python-setuptools \
         zlib1g-dev \
     ' \
     && apt-get install -y --no-install-recommends \
@@ -71,25 +69,18 @@ RUN set -ex \
         libxml2 \
         libxslt1.1 \
         pwgen \
-        python \
-        python-pip \
-        python-psycopg2 \
-        python-virtualenv \
-	python-jinja2 \
         sqlite \
         zlib1g \
     ; \
-    python -m pip install --upgrade pip ;\
-    python -m pip install --upgrade wheel ;\
-    python -m pip install --upgrade python-ldap ;\
-    python -m pip install --upgrade lxml ;\
-    python -m pip install --upgrade supervisor \
+    python3 -m pip install --upgrade wheel ;\
+    python3 -m pip install --upgrade python-ldap ;\
+    python3 -m pip install --upgrade lxml \
     ; \
-    git clone --branch $BV_SYN --depth 1 https://github.com/matrix-org/synapse.git \
+    git clone --branch hawkowl/py3-3 --depth 1 https://github.com/matrix-org/synapse.git \
     && cd /synapse \
-    git checkout tags/$TAG_SYN \
+    git checkout tags/hawkowl/py3-3 \
     && python -m pip install --upgrade --process-dependency-links . \
-    && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse $BV_SYN | cut -f 1) \
+    && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse hawkowl/py3-3 | cut -f 1) \
     && echo "synapse: $BV_SYN ($GIT_SYN)" >> /synapse.version \
     && cd / \
     && rm -rf /synapse \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN set -ex \
         libxslt1-dev \
         linux-headers-amd64 \
         make \
-        zlib1g-dev \ 
+        zlib1g-dev \
         python3-dev \
         python3-setuptools \
         libpq-dev \
@@ -81,7 +81,7 @@ RUN set -ex \
     git clone --branch $BV_SYN --depth 1 https://github.com/matrix-org/synapse.git \
     && cd /synapse \
     git checkout tags/$TAG_SYN \
-    && pip install --upgrade .[all] \
+    && pip3 install --upgrade .[all] \
     && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse $BV_SYN | cut -f 1) \
     && echo "synapse: $BV_SYN ($GIT_SYN)" >> /synapse.version \
     && cd / \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.34.1.1
+ARG TAG_SYN=v0.99.0
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.99.3
+ARG TAG_SYN=v0.99.3.2
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.33.5.1
+ARG TAG_SYN=v0.33.6
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991
@@ -67,14 +67,14 @@ RUN set -ex \
         sqlite \
         zlib1g \
     ; \
-    python -m pip install --upgrade wheel ;\
-    python -m pip install --upgrade python-ldap ;\
-    python -m pip install --upgrade lxml \
+    pip install --upgrade wheel ;\
+    pip install --upgrade python-ldap ;\
+    pip install --upgrade lxml \
     ; \
     git clone --branch $BV_SYN --depth 1 https://github.com/matrix-org/synapse.git \
     && cd /synapse \
     git checkout tags/$TAG_SYN \
-    && python -m pip install --upgrade --process-dependency-links . \
+    && pip install --upgrade --process-dependency-links . \
     && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse $BV_SYN | cut -f 1) \
     && echo "synapse: $BV_SYN ($GIT_SYN)" >> /synapse.version \
     && cd / \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN set -ex \
         zlib1g \
     ; \
     pip install --upgrade wheel ;\
+    pip install --upgrade psycopg2;\
     pip install --upgrade python-ldap ;\
     pip install --upgrade lxml \
     ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.33.8
+ARG TAG_SYN=v0.33.9
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,14 @@ RUN set -ex \
     && cd / \
     && rm -rf /synapse \
     ; \
+    groupadd -r -g $MATRIX_GID matrix \
+    && useradd -r -d /data -M -u $MATRIX_UID -g matrix matrix \
+    && chown $MATRIX_UID:$MATRIX_GID /data/* \
+    && chown -R $MATRIX_UID:$MATRIX_GID /data \
+    && chown -R $MATRIX_UID:$MATRIX_GID /uploads \
+    && chmod a+rwx /run \
+    ; \
     apt-get autoremove -y $buildDeps ; \
     apt-get autoremove -y ;\
     rm -rf /var/lib/apt/* /var/cache/apt/*
+USER matrix

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ EXPOSE 8448
 VOLUME ["/data"]
 
 # Git branch to build from
-ARG BV_SYN=develop
+ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.33.4
+ARG TAG_SYN=v0.33.5.1
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991
@@ -67,15 +67,15 @@ RUN set -ex \
         sqlite \
         zlib1g \
     ; \
-    python3 -m pip install --upgrade wheel ;\
-    python3 -m pip install --upgrade python-ldap ;\
-    python3 -m pip install --upgrade lxml \
+    python -m pip install --upgrade wheel ;\
+    python -m pip install --upgrade python-ldap ;\
+    python -m pip install --upgrade lxml \
     ; \
-    git clone --branch develop --depth 1 https://github.com/matrix-org/synapse.git \
+    git clone --branch $BV_SYN --depth 1 https://github.com/matrix-org/synapse.git \
     && cd /synapse \
-    && git checkout develop \
+    git checkout tags/$TAG_SYN \
     && python -m pip install --upgrade --process-dependency-links . \
-    && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse develop | cut -f 1) \
+    && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse $BV_SYN | cut -f 1) \
     && echo "synapse: $BV_SYN ($GIT_SYN)" >> /synapse.version \
     && cd / \
     && rm -rf /synapse \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.33.9
+ARG TAG_SYN=v0.34.0
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -24,7 +24,7 @@ generate_turn_key() {
 generate_synapse_file() {
 	local filepath="${1}"
 
-	python3 -m synapse.app.homeserver \
+	python -m synapse.app.homeserver \
 	       --config-path "${filepath}" \
 	       --generate-config \
 	       --report-stats ${REPORT_STATS} \
@@ -87,20 +87,14 @@ case $OPTION in
 		chown -R $MATRIX_UID:$MATRIX_GID /data &
 		chown -R $MATRIX_UID:$MATRIX_GID /uploads &
 		chmod a+rwx /run
-		exec su -c "python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf"  matrix
+        exec su -c "python -m synapse.app.homeserver --config-path /data/homeserver.yaml" matrix &
+        exec su -c "/usr/bin/turnserver -c /data/turnserver.conf" matrix
 		;;
 
 	"autostart")
 		if [ -f /data/homeserver.yaml ]; then
             if [ -f /data/turnserver.conf ]; then
                 echo "-=> start turn"
-                if [ -f /conf/supervisord-turnserver.conf.deactivated ]; then
-                    mv -f /conf/supervisord-turnserver.conf.deactivated /conf/supervisord-turnserver.conf
-                fi
-            else
-                if [ -f /conf/supervisord-turnserver.conf ]; then
-                    mv -f /conf/supervisord-turnserver.conf /conf/supervisord-turnserver.conf.deactivated
-                fi
             fi
             (
                 if [ -f /data/vector.im.conf ] || [ -f /data/riot.im.conf ] ; then
@@ -114,7 +108,8 @@ case $OPTION in
             chown -R $MATRIX_UID:$MATRIX_GID /data &
             chown -R $MATRIX_UID:$MATRIX_GID /uploads &
             chmod a+rwx /run
-            exec su -c "python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf" matrix
+            exec su -c "python -m synapse.app.homeserver --config-path /data/homeserver.yaml" matrix &
+            exec su -c "/usr/bin/turnserver -c /data/turnserver.conf" matrix
         else
             breakup="0"
             [[ -z "${SERVER_NAME}" ]] && echo "STOP! environment variable SERVER_NAME must be set" && breakup="1"

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -81,12 +81,6 @@ case $OPTION in
 		)
 
 		echo "-=> start matrix"
-		groupadd -r -g $MATRIX_GID matrix
-		useradd -r -d /data -M -u $MATRIX_UID -g matrix matrix
-		chown $MATRIX_UID:$MATRIX_GID /data/*
-		chown -R $MATRIX_UID:$MATRIX_GID /data &
-		chown -R $MATRIX_UID:$MATRIX_GID /uploads &
-		chmod a+rwx /run
         	exec python -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
 		;;
 
@@ -101,12 +95,6 @@ case $OPTION in
                 fi
             )
             echo "-=> start matrix"
-            groupadd -r -g $MATRIX_GID matrix
-            useradd -r -d /data -M -u $MATRIX_UID -g matrix matrix
-            chown $MATRIX_UID:$MATRIX_GID /data/*
-            chown -R $MATRIX_UID:$MATRIX_GID /data &
-            chown -R $MATRIX_UID:$MATRIX_GID /uploads &
-            chmod a+rwx /run
 	    exec python -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
         else
             breakup="0"

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -87,7 +87,7 @@ case $OPTION in
 		chown -R $MATRIX_UID:$MATRIX_GID /data &
 		chown -R $MATRIX_UID:$MATRIX_GID /uploads &
 		chmod a+rwx /run
-		exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml
+		exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
 		;;
 
 	"autostart")
@@ -114,7 +114,7 @@ case $OPTION in
             chown -R $MATRIX_UID:$MATRIX_GID /data &
             chown -R $MATRIX_UID:$MATRIX_GID /uploads &
             chmod a+rwx /run
-            exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml
+            exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
         else
             breakup="0"
             [[ -z "${SERVER_NAME}" ]] && echo "STOP! environment variable SERVER_NAME must be set" && breakup="1"

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -87,7 +87,7 @@ case $OPTION in
 		chown -R $MATRIX_UID:$MATRIX_GID /data &
 		chown -R $MATRIX_UID:$MATRIX_GID /uploads &
 		chmod a+rwx /run
-		exec su -c "python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml"  matrix & su -c "/usr/bin/turnserver -c /data/turnserver.conf"  matrix
+		exec su -c "python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf"  matrix
 		;;
 
 	"autostart")
@@ -114,7 +114,7 @@ case $OPTION in
             chown -R $MATRIX_UID:$MATRIX_GID /data &
             chown -R $MATRIX_UID:$MATRIX_GID /uploads &
             chmod a+rwx /run
-            exec su -c "python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml" matrix & su -c " /usr/bin/turnserver -c /data/turnserver.conf" matrix
+            exec su -c "python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf" matrix
         else
             breakup="0"
             [[ -z "${SERVER_NAME}" ]] && echo "STOP! environment variable SERVER_NAME must be set" && breakup="1"

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -87,7 +87,7 @@ case $OPTION in
 		chown -R $MATRIX_UID:$MATRIX_GID /data &
 		chown -R $MATRIX_UID:$MATRIX_GID /uploads &
 		chmod a+rwx /run
-		exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
+		exec su -c "python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml"  matrix & su -c "/usr/bin/turnserver -c /data/turnserver.conf"  matrix
 		;;
 
 	"autostart")
@@ -114,7 +114,7 @@ case $OPTION in
             chown -R $MATRIX_UID:$MATRIX_GID /data &
             chown -R $MATRIX_UID:$MATRIX_GID /uploads &
             chmod a+rwx /run
-            exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
+            exec su -c "python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml" matrix & su -c " /usr/bin/turnserver -c /data/turnserver.conf" matrix
         else
             breakup="0"
             [[ -z "${SERVER_NAME}" ]] && echo "STOP! environment variable SERVER_NAME must be set" && breakup="1"

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -24,7 +24,7 @@ generate_turn_key() {
 generate_synapse_file() {
 	local filepath="${1}"
 
-	python synapse.app.homeserver \
+	python3 synapse.app.homeserver \
 	       --config-path "${filepath}" \
 	       --generate-config \
 	       --report-stats ${REPORT_STATS} \
@@ -81,7 +81,7 @@ case $OPTION in
 		)
 
 		echo "-=> start matrix"
-        	exec python -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
+        	exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
 		;;
 
 	"autostart")
@@ -95,7 +95,7 @@ case $OPTION in
                 fi
             )
             echo "-=> start matrix"
-	    exec python -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
+	    exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
         else
             breakup="0"
             [[ -z "${SERVER_NAME}" ]] && echo "STOP! environment variable SERVER_NAME must be set" && breakup="1"

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -24,7 +24,7 @@ generate_turn_key() {
 generate_synapse_file() {
 	local filepath="${1}"
 
-	python -m synapse.app.homeserver \
+	python3 -m synapse.app.homeserver \
 	       --config-path "${filepath}" \
 	       --generate-config \
 	       --report-stats ${REPORT_STATS} \
@@ -87,7 +87,7 @@ case $OPTION in
 		chown -R $MATRIX_UID:$MATRIX_GID /data &
 		chown -R $MATRIX_UID:$MATRIX_GID /uploads &
 		chmod a+rwx /run
-		exec supervisord -c /supervisord.conf
+		exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml
 		;;
 
 	"autostart")
@@ -114,7 +114,7 @@ case $OPTION in
             chown -R $MATRIX_UID:$MATRIX_GID /data &
             chown -R $MATRIX_UID:$MATRIX_GID /uploads &
             chmod a+rwx /run
-            exec supervisord -c /supervisord.conf
+            exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml
         else
             breakup="0"
             [[ -z "${SERVER_NAME}" ]] && echo "STOP! environment variable SERVER_NAME must be set" && breakup="1"

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -24,7 +24,7 @@ generate_turn_key() {
 generate_synapse_file() {
 	local filepath="${1}"
 
-	python -m synapse.app.homeserver \
+	python synapse.app.homeserver \
 	       --config-path "${filepath}" \
 	       --generate-config \
 	       --report-stats ${REPORT_STATS} \
@@ -87,8 +87,7 @@ case $OPTION in
 		chown -R $MATRIX_UID:$MATRIX_GID /data &
 		chown -R $MATRIX_UID:$MATRIX_GID /uploads &
 		chmod a+rwx /run
-        exec su -c "python -m synapse.app.homeserver --config-path /data/homeserver.yaml" matrix &
-        exec su -c "/usr/bin/turnserver -c /data/turnserver.conf" matrix
+        	exec python -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
 		;;
 
 	"autostart")
@@ -108,8 +107,7 @@ case $OPTION in
             chown -R $MATRIX_UID:$MATRIX_GID /data &
             chown -R $MATRIX_UID:$MATRIX_GID /uploads &
             chmod a+rwx /run
-            exec su -c "python -m synapse.app.homeserver --config-path /data/homeserver.yaml" matrix &
-            exec su -c "/usr/bin/turnserver -c /data/turnserver.conf" matrix
+	    exec python -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
         else
             breakup="0"
             [[ -z "${SERVER_NAME}" ]] && echo "STOP! environment variable SERVER_NAME must be set" && breakup="1"

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -81,7 +81,7 @@ case $OPTION in
 		)
 
 		echo "-=> start matrix"
-        	exec python -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
+        	exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
 		;;
 
 	"autostart")
@@ -95,7 +95,7 @@ case $OPTION in
                 fi
             )
             echo "-=> start matrix"
-	    exec python -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
+	    exec python3 -m synapse.app.homeserver --config-path /data/homeserver.yaml & /usr/bin/turnserver -c /data/turnserver.conf
         else
             breakup="0"
             [[ -z "${SERVER_NAME}" ]] && echo "STOP! environment variable SERVER_NAME must be set" && breakup="1"

--- a/adds/supervisord-matrix.conf
+++ b/adds/supervisord-matrix.conf
@@ -1,7 +1,0 @@
-[program:matrix]
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-user=matrix
-command=/usr/bin/python -m synapse.app.homeserver --config-path /data/homeserver.yaml

--- a/adds/supervisord-turnserver.conf
+++ b/adds/supervisord-turnserver.conf
@@ -1,7 +1,0 @@
-[program:turnserver]
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-user=matrix
-command=/usr/bin/turnserver -c /data/turnserver.conf

--- a/adds/supervisord.conf
+++ b/adds/supervisord.conf
@@ -1,5 +1,0 @@
-[supervisord]
-nodaemon = true
-
-[include]
-files = conf/*.conf


### PR DESCRIPTION
This should allow running synapse from python 3, as the matrix user (uid 991 gid 991).
To make the image small we start from a debian stretch slim base, and install python 3 from there. This means we're running python 3.5, which may negatively impact performance compared to python 3.7, but it ought to be better than python 2.

Downside of this method is that we lose the ability to change the uid and gid of the matrix user running synapse with the environmental variables.

I tested this with both sqlite and postgresql.