### PR TITLE
Fix backwards compatibility issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.99.4
+ARG TAG_SYN=v0.99.5
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,4 +87,5 @@ RUN set -ex \
     ; \
     apt-get autoremove -y $buildDeps ; \
     apt-get autoremove -y ;\
-    rm -rf /var/lib/apt/* /var/cache/apt/*
+    rm -rf /var/lib/apt/* /var/cache/apt/* \
+    && chmod 777 /run 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,14 +85,6 @@ RUN set -ex \
     && cd / \
     && rm -rf /synapse \
     ; \
-    groupadd -r -g $MATRIX_GID matrix \
-    && useradd -r -d /data -M -u $MATRIX_UID -g matrix matrix \
-    && chown $MATRIX_UID:$MATRIX_GID /data/* \
-    && chown -R $MATRIX_UID:$MATRIX_GID /data \
-    && chown -R $MATRIX_UID:$MATRIX_GID /uploads \
-    && chmod a+rwx /run \
-    ; \
     apt-get autoremove -y $buildDeps ; \
     apt-get autoremove -y ;\
     rm -rf /var/lib/apt/* /var/cache/apt/*
-USER matrix

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=master
 ARG BV_TUR=master
-ARG TAG_SYN=v0.99.5
+ARG TAG_SYN=v0.99.5.1
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ We are working with the repository at "https://github.com/AVENTER-UG/docker-matr
 
 ## Security
 
-We verify the docker layers of our image automaticly with clair. Matrix is not a part of the vulnerabilitie scan, which  means clair will only find vulnerabilities that are part of the OS (operating system).
+We verify the docker layers of our image automaticly with clair. Matrix is not a part of the vulnerability scan, which  means clair will only find vulnerabilities that are part of the OS (operating system).
 
 ## Introduction
 
@@ -46,19 +46,20 @@ there is also an [example setup](Example.configs.md) available to read.
 
 [readme file]: https://github.com/matrix-org/synapse/blob/master/README.rst
 
-To get the things done, "generate" will create a self-signed certificate, which
-can be used for federation.
+To get the things done, "generate" will create a self-signed certificate, which should be replaced with a valid certificate if used in production, either by giving synapse access to the valid certificate, or by using a reverse proxy.
+
+It is recommended to run the container with a --user <UID>:<GID> flag, to prevent the container from running as root. However, the synapse process will not run as root if the user flag is not supplied.
 
 Example:
 
-    $ docker run -v /tmp/data:/data --rm -e SERVER_NAME=localhost -e REPORT_STATS=no avhost/docker-matrix:<VERSION> generate
+    $ docker run -v /tmp/data:/data --rm --user 991:991 -e SERVER_NAME=localhost -e REPORT_STATS=no avhost/docker-matrix:<VERSION> generate
 
 ## Start
 
 For starting you need the port bindings and a mapping for the
 `/data`-directory.
 
-    $ docker run -d -p 8448:8448 -p 8008:8008 -p 3478:3478 -v /tmp/data:/data avhost/docker-matrix:<VERSION> start
+    $ docker run -d --user 991:991 -p 8448:8448 -p 8008:8008 -p 3478:3478 -v /tmp/data:/data avhost/docker-matrix:<VERSION> start
 
 ## Port configurations
 
@@ -105,7 +106,7 @@ argument or look at the container via cat.
 * `REPORT_STATS`: statistic report, mandatory, values: `yes` or `no`, needed
   only for `generate`
 * `MATRIX_UID`/`MATRIX_GID`: UserID and GroupID of user within container which
-  runs the synapse server. The files mounted under /data are `chown`ed to this
+  runs the synapse server, if the --user flag is not supplied. The files mounted under /data are `chown`ed to this
   ownership. Default is `MATRIX_UID=991` and `MATRIX_GID=991`. It can overriden
   via `-e MATRIX_UID=...` and `-e MATRIX_GID=...` at start time.
 


### PR DESCRIPTION
By checking whether the start.sh script runs as root, we can both support using the `--user` flag, and run synapse as the uid/gid supplied in the `MATRIX_UID` and `MATRIX_GID`  environmental variables.

I see two downsides to this solution:
1. We don't default to running the container as the matrix user (but I did edit the readme to suggest adding a --user flag on running)
2. It adds more complexity to the start.sh script, and ` su matrix -c ` isn't the most pretty solution.

I would advocate using this branch.