### PR TITLE
Run synapse with jemalloc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
         python3-pip \
         python3-jinja2 \
         sqlite \
+        libjemalloc1 \
         zlib1g \
     ; \
     pip3 install --upgrade wheel ;\
@@ -90,3 +91,4 @@ RUN set -ex \
     && rm -rf /synapse 
 
 USER matrix
+ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,9 @@ argument or look at the container via cat.
   runs the synapse server, if the --user flag is not supplied. The files mounted under /data are `chown`ed to this
   ownership. Default is `MATRIX_UID=991` and `MATRIX_GID=991`. It can overriden
   via `-e MATRIX_UID=...` and `-e MATRIX_GID=...` at start time.
+* `LD_PRELOAD` This is set by default to use jemalloc as memory allocator, as 
+  that has been shown to greatly reduce the memory useage of synapse. To use the default malloc
+  the environmental variable has to be emptied, by adding `-e LD_PRELOAD` when running the container.
 
 ## build specific arguments
 


### PR DESCRIPTION
This change should decrease the memory usage of synapse by quite a lot. If you want to disable jemalloc, this can be done by adding `-e LD_PRELOAD` to the run command (effectively emptying the LD_PRELOAD environmental variable.)