### PR TITLE
Remove build deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ EXPOSE 8448
 VOLUME ["/data"]
 
 # Git branch to build from
-ARG BV_SYN=release-v1.4.0
+ARG BV_SYN=release-v1.4.1
 ARG BV_TUR=master
-ARG TAG_SYN=v1.4.0
+ARG TAG_SYN=v1.4.1
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 # Git branch to build from
 ARG BV_SYN=release-v1.6.0
 ARG BV_TUR=master
-ARG TAG_SYN=v1.6.0rc2
+ARG TAG_SYN=v1.6.0
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,6 @@ RUN set -ex \
     pip3 install --upgrade wheel ;\
     pip3 install --upgrade psycopg2;\
     pip3 install --upgrade python-ldap ;\
-    pip3 install git+https://github.com/t2bot/synapse-simple-antispam#egg=synapse-simple-antispam ;\
     pip3 install --upgrade lxml \
     ; \
     groupadd -r -g $MATRIX_GID matrix \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ EXPOSE 8448
 VOLUME ["/data"]
 
 # Git branch to build from
-ARG BV_SYN=release-v1.6.0
+ARG BV_SYN=release-v1.6.1
 ARG BV_TUR=master
-ARG TAG_SYN=v1.6.0
+ARG TAG_SYN=v1.6.1
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991
@@ -89,7 +89,11 @@ RUN set -ex \
     && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse $BV_SYN | cut -f 1) \
     && echo "synapse: $BV_SYN ($GIT_SYN)" >> /synapse.version \
     && cd / \
-    && rm -rf /synapse 
+    && rm -rf /synapse \
+    ; \
+    apt-get autoremove -y $buildDeps ; \
+    apt-get autoremove -y ;\
+    rm -rf /var/lib/apt/* /var/cache/apt/*
 
 USER matrix
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ EXPOSE 8448
 VOLUME ["/data"]
 
 # Git branch to build from
-ARG BV_SYN=master
+ARG BV_SYN=release-v1.4.0
 ARG BV_TUR=master
-ARG TAG_SYN=v1.1.0
+ARG TAG_SYN=v1.4.0
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991
@@ -75,6 +75,7 @@ RUN set -ex \
     pip3 install --upgrade wheel ;\
     pip3 install --upgrade psycopg2;\
     pip3 install --upgrade python-ldap ;\
+    pip3 install git+https://github.com/t2bot/synapse-simple-antispam#egg=synapse-simple-antispam ;\
     pip3 install --upgrade lxml \
     ; \
     groupadd -r -g $MATRIX_GID matrix \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ EXPOSE 8448
 VOLUME ["/data"]
 
 # Git branch to build from
-ARG BV_SYN=release-v1.4.1
+ARG BV_SYN=release-v1.6.0
 ARG BV_TUR=master
-ARG TAG_SYN=v1.4.1
+ARG TAG_SYN=v1.6.0rc2
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991


### PR DESCRIPTION
Somewhere the removal of the build deps was removed from the dockerfile, probably my fault when moving to python 3. This results in images that are larger than needed.