### PR TITLE
Add travisfile to build and push docker-images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: generic
+sudo: required
+dist: bionic
+services:
+- docker
+jobs:
+  include:
+  - stage: build docker image
+    script:
+    - echo "===== building docker image ===="
+    - docker build -t nebukadneza/docker-matrix:latest .
+    - docker images
+    - echo "===== preparing to run testing image ===="
+    - mkdir tmp && sudo chown 991:991 tmp/
+    - docker run --name synapse-generate -v ${PWD}/tmp/:/data --rm --user 991:991 -e SERVER_NAME=localhost -e
+      REPORT_STATS=no nebukadneza/docker-matrix:latest generate
+    - sudo sed -i -e "s/\['::1', '127.0.0.1'\]/['0.0.0.0']/" tmp/homeserver.yaml
+    - sudo sed -i -e "s/\['::', '0.0.0.0'\]/['0.0.0.0']/" tmp/homeserver.yaml
+    - echo "===== starting up testing image ===="
+    - docker run --name synapse-test -d --user 991:991 -p 8008:8008 -v ${PWD}/tmp/:/data
+      nebukadneza/docker-matrix:latest start
+    - echo "===== waiting for testing docker to reply to version endpoint (simple test) ===="
+    - timeout 1m bash -c 'until curl http://localhost:8008/_matrix/client/versions ; do sleep 5 ; done'
+    - docker logs synapse-test
+    after_success:
+    - echo "===== pushing to docker-hub ===="
+    - echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+    - docker push nebukadneza/docker-matrix:latest
+env:
+  global:
+  - secure: TODO
+  - secure: TODO


### PR DESCRIPTION
Add travisfile to build and push docker-images

Travis is a free-for-FOSS-projects CI pipeline service. Here, we use travis to build and upload the docker-image of docker-matrix.

The big advantage of this is that the build are visible for all to see, and thus more trustworthy.  Furthermore, contributors can improve or fix the build-pipeline as well as debug it themselves. This may be beneficial to the project as a whole.

Furthermore, a simple test of the container is performed. This test merely generates a config, waits for the container to start up, and checks if it can connect to the version-endpoint of the API. More tests can be added in this fashion in the future.

In this commit, there are 2 TODOs in the `yaml`-file. These need to be filled by the maintainer using the  travis` cli client:

`travis encrypt DOCKERHUB_USERNAME=<her/his user> --add env.global`
`travis encrypt DOCKERHUB_PASSWORD=<her/his pass> --add env.global`

After that, the travis github-app needs to be activated for the repository.

An example of a successful build can be seen at:
https://travis-ci.org/Nebukadneza/docker-matrix/builds/645674225
which got pushed to:
https://hub.docker.com/r/nebukadneza/docker-matrix
The build after that already includes the TODO in the `yaml`-file, and thus fails.