### PR TITLE
trixie as builder for compatible rustc version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # target architecture
-FROM debian:bookworm-slim as builder
+FROM debian:trixie-slim as builder
 
 # Git branch to build from
-ARG BV_SYN=release-v1.99
+ARG BV_SYN=release-v1.100
 ARG BV_TUR=master
-ARG TAG_SYN=v1.99.0
+ARG TAG_SYN=v1.100.0rc3
 
 # user configuration
 ENV MATRIX_UID=991 MATRIX_GID=991


### PR DESCRIPTION
For 1.100 it seems that rustc <1.65 is needed, while debian bookworm packages rustc 1.63. By basing the builder on debian testing we get a compatible rust version.

I think this is more a workaround than anything else, but it does work.